### PR TITLE
Add Ability to mask passwords in the UI and in saved Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## 2.0.0 (2019-04-12)
+## 2.0.0 - 2.0.1 (2019-04-12)
 
 - Remove dependency_links from setup.py to regain compatibility with recent pip versions
 - Change MARA_XXX variables to functions to delay importing of imports
 - move some imports into the functions that use them in order to improve loading speed
+- Add ability to mask passwords in `Command`s, so they cannot show up in the UI anymore
+  or are not written to the database in saved Events (config
+  `data_integration.config.password_masks()`). See the example in the original function
+  how to not let passwords show up in the settings UI.
+  ([gh #14](https://github.com/mara/data-integration/pull/14))
 
 **required changes** 
 

--- a/data_integration/config.py
+++ b/data_integration/config.py
@@ -3,6 +3,7 @@
 import datetime
 import multiprocessing
 import pathlib
+import typing
 
 from . import pipelines
 
@@ -69,3 +70,15 @@ def slack_token() -> str:
     channel's app "Incoming WebHooks" configuration as part part of the Webhook URL
     """
     return None
+
+def password_masks() -> typing.List[str]:
+    """Any passwords which should be masked in the UI or logs"""
+
+    # If you don't want to show the passwords in the password dialog, use something like this
+    # to hide them there as well:
+    #
+    # class MasksList(list):
+    #     def __repr__(self):
+    #         return f"<MasksList with {len(self)} elements>"
+
+    return []

--- a/data_integration/logging/logger.py
+++ b/data_integration/logging/logger.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime
 
 from ..logging import events
+import data_integration.config
 
 Format = events.Output.Format
 
@@ -15,13 +16,20 @@ def log(message: str, format: events.Output.Format = Format.STANDARD,
     Logs text messages.
 
     When run inside a pipeline, this will send a log message to the parent process.
-    Otherwise, messages will be printed to `sys.stdout` and `sys.stderr`
+    Otherwise, messages will be printed to `sys.stdout` and `sys.stderr`.
+
+    Any string in `data_integration.config.password_masks()` will be replaced by '***'.
+
     Args:
         message: The message to display
         format: How to format the message
         is_error: Whether the message is considered an error message
     """
     message = message.rstrip()
+    masks = data_integration.config.password_masks()
+    if masks:
+        for mask in masks:
+            message = message.replace(mask, '***')
     if message:
         if _event_queue:
             _event_queue.put(events.Output(_node_path, message, format, is_error))

--- a/data_integration/ui/node_page.py
+++ b/data_integration/ui/node_page.py
@@ -116,8 +116,18 @@ def __(task: pipelines.ParallelTask):
 
 def _render_command(command: pipelines.Command):
     """Creates a html documentation for a command"""
+    from mara_page.xml import render
+
+    def __mask_passwords(content):
+        masks = config.password_masks()
+        if masks:
+            content = ''.join(render(content))
+            for mask in masks:
+                content = content.replace(mask, "***")
+        return content
+
     try:
-        doc = bootstrap.table([], [_.tr[_.td[_.div[section]], _.td(style='width:90%')[content]]
+        doc = bootstrap.table([], [_.tr[_.td[_.div[section]], _.td(style='width:90%')[__mask_passwords(content)]]
                                    for section, content in command.html_doc_items()])
     except Exception as e:
         import traceback


### PR DESCRIPTION
We don't want passwords saved to any disk/DB or shown in any UI so we need the ability to mask them. This masks passwords in the log (before it's actually shown/written) and in the node pages. I'm not sure if there are more places.