### PR TITLE
Timezones everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2.2.0 (2019-07-02)
+- Changed all `TIMSTAMP` to `TIMSTAMPTZ` in the mara tables. You have to manually run the
+  below migration commands as `make migrate-mara-db` won't pick up this change.
+
+**required changes**
+You need to manually convert the mara tables to `TIMESTAMPTZ`:
+
+```SQL
+-- Change the timezone to whatever your ETL process is running in
+ALTER TABLE data_integration_run ALTER start_time TYPE timestamptz
+  USING start_time AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_run ALTER end_time TYPE timestamptz
+  USING end_time AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_processed_file ALTER last_modified_timestamp TYPE timestamptz
+  USING last_modified_timestamp AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_node_run ALTER start_time TYPE timestamptz
+  USING start_time AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_node_run ALTER end_time TYPE timestamptz
+  USING end_time AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_node_output ALTER timestamp TYPE timestamptz
+  USING timestamp AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_file_dependency ALTER timestamp TYPE timestamptz
+  USING timestamp AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_integration_system_statistics ALTER timestamp TYPE timestamptz
+  USING timestamp AT TIME ZONE 'Europe/Berlin';
+```
+
 ## 2.1.0 (2019-05-15)
 
 - Track and visualize also unfinished pipeline runs

--- a/data_integration/incremental_processing/file_dependencies.py
+++ b/data_integration/incremental_processing/file_dependencies.py
@@ -19,7 +19,7 @@ class FileDependency(Base):
     node_path = sqlalchemy.Column(sqlalchemy.ARRAY(sqlalchemy.TEXT), primary_key=True)
     dependency_type = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
     hash = sqlalchemy.Column(sqlalchemy.String)
-    timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP)
+    timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True))
 
 
 def update(node_path: [str], dependency_type: str, pipeline_base_path: str, file_dependencies: [str]):

--- a/data_integration/incremental_processing/processed_files.py
+++ b/data_integration/incremental_processing/processed_files.py
@@ -18,7 +18,7 @@ class ProcessedFile(Base):
 
     node_path = sqlalchemy.Column(sqlalchemy.ARRAY(sqlalchemy.Text), primary_key=True)
     file_name = sqlalchemy.Column(sqlalchemy.Text, primary_key=True)
-    last_modified_timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP)
+    last_modified_timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True))
 
 
 def track_processed_file(node_path: str, file_name: str, last_modified_timestamp: datetime):

--- a/data_integration/logging/run_log.py
+++ b/data_integration/logging/run_log.py
@@ -18,8 +18,8 @@ class Run(Base):
     run_id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
     node_path = sqlalchemy.Column(sqlalchemy.ARRAY(sqlalchemy.TEXT), nullable=False, index=True)
     pid = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-    start_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP, nullable=False)
-    end_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP)
+    start_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True), nullable=False)
+    end_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True))
     succeeded = sqlalchemy.Column(sqlalchemy.BOOLEAN)
 
 
@@ -31,8 +31,8 @@ class NodeRun(Base):
     run_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('data_integration_run.run_id'), index=True)
 
     node_path = sqlalchemy.Column(sqlalchemy.ARRAY(sqlalchemy.TEXT), index=True)
-    start_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP, nullable=False)
-    end_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP)
+    start_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True), nullable=False)
+    end_time = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True))
     succeeded = sqlalchemy.Column(sqlalchemy.BOOLEAN)
     is_pipeline = sqlalchemy.Column(sqlalchemy.BOOLEAN)
 
@@ -44,7 +44,7 @@ class NodeOutput(Base):
     node_output_id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
     node_run_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('data_integration_node_run.node_run_id'),
                                     index=True)
-    timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP, nullable=False)
+    timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True), nullable=False)
     message = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
     format = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
     is_error = sqlalchemy.Column(sqlalchemy.BOOLEAN, nullable=False)
@@ -54,7 +54,7 @@ class SystemStatistics(Base):
     """System stats measurements"""
     __tablename__ = 'data_integration_system_statistics'
 
-    timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP, primary_key=True, index=True)
+    timestamp = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True), primary_key=True, index=True)
     disc_read = sqlalchemy.Column(sqlalchemy.FLOAT)
     disc_write = sqlalchemy.Column(sqlalchemy.FLOAT)
     net_recv = sqlalchemy.Column(sqlalchemy.FLOAT)

--- a/data_integration/ui/run_time_chart.sql
+++ b/data_integration/ui/run_time_chart.sql
@@ -4,7 +4,7 @@ DROP TYPE IF EXISTS pg_temp.RUN_STAT CASCADE;
 
 CREATE TYPE pg_temp.RUN_STAT AS (
   run_id INTEGER, -- for debugging
-  start_time TIMESTAMP, -- either the start time of the node or the first of its child nodes
+  start_time TIMESTAMPTZ, -- either the start time of the node or the first of its child nodes
   node_name TEXT, -- the name of the node that is run
   node_run JSONB, -- data about the run of the node itself
   child_names TEXT[], -- names of all child nodes


### PR DESCRIPTION
This changes the timestamps in all mara tables in data-integration to include timezones. This enables us to properly use these timestamps in monitoring.