### PR TITLE
Fix open runs after browser reload

### DIFF
--- a/data_integration/logging/events.py
+++ b/data_integration/logging/events.py
@@ -24,7 +24,7 @@ class EventHandler(abc.ABC):
         pass
 
 
-class PipelineEvent():
+class PipelineEvent(Event):
     def __init__(self, node_path: [str]) -> None:
         """
         Base class for events that are emitted during a pipeline run.
@@ -33,6 +33,7 @@ class PipelineEvent():
             node_path: The path of the current node in the data pipeline that is run
 
         """
+        super().__init__()
         self.node_path = node_path
 
     def to_json(self):


### PR DESCRIPTION
When closing a browser window (or press reload during a running ETL), the generator gets closed with GeneratorExit but we didn't close the runs/node_runs.

Similar things happened when the process was killed by SIGINT.

Now we close the runs/node_runs on both an aborted window/reload and SIGINT.