### PR TITLE
Speedup incremental insert into partitioned tables

### DIFF
--- a/data_integration/commands/sql.py
+++ b/data_integration/commands/sql.py
@@ -321,6 +321,9 @@ class CopyIncrementally(_SQLCommand):
                 if self.use_explicit_upsert:
                     set_clause = ', '.join([f'"{col[0]}" = src."{col[0]}"' for col in cursor.fetchall()])
                     key_definition = ' AND '.join([f'dst."{k}" = src."{k}"' for k in self.primary_keys])
+                    # one could also use dst.* IS NULL but this somehow prevents pg10 from using parallel aggregate
+                    # which means a lot slow down on highly partitioned tables (e.g. chuncked)
+                    where_null_condition = ' OR '.join([f'dst."{k}" IS NULL' for k in self.primary_keys])
                 else:
                     set_clause = ', '.join([f'"{col[0]}" = EXCLUDED."{col[0]}"' for col in cursor.fetchall()])
                     key_definition = ', '.join(['"' + primary_key + '"' for primary_key in self.primary_keys])
@@ -338,7 +341,7 @@ SELECT src.*
 FROM {self.target_table}_upsert src
 LEFT JOIN {self.target_table} dst
   ON {key_definition}
-WHERE dst.* IS NULL"""
+WHERE {where_null_condition}"""
                 if not shell.run_shell_command(f'echo {shlex.quote(update_query)} \\\n  | '
                                                + mara_db.shell.query_command(self.target_db_alias, echo_queries=True)):
                     return False


### PR DESCRIPTION
When having a partitioned table where incremental load is inserted into, this speeds up the insert by making scanning the dst table parallel

Comparing the following queries (all resulting in zero results as the insert already happened):

```SQL
-- Uses Append on a Seq Scan on all children with a Hash Right Join
Explain Analyse
SELECT src.*
FROM os_data.whatever_upsert src
LEFT JOIN os_data.whatever dst
  ON dst."id" = src."id"
WHERE dst.* IS NULL
-- Execution Time: 58464.012 ms
```

```SQL
-- Uses Parallel Append on a Parallel Seq Scan with a Parallel Hash Anti Join
Explain Analyse
SELECT src.*
FROM os_data.whatever_upsert src
LEFT JOIN os_data.whatever dst
  ON dst."id" = src."id"
WHERE dst.id IS NULL
-- Execution Time: 14804.001 ms
```

```SQL
-- Again Uses Parallel Append on a Parallel Seq Scan with a Parallel Hash Anti Join
-- when I developed this with less upsert data it used the Index in the id column
Explain Analyse
SELECT src.*
FROM os_data.job_match_2019_upsert src
WHERE NOT EXISTS (SELECT 1 FROM os_data.job_match_2019 dst WHERE dst."id" = src."id")
-- Execution Time: 14465.946 ms
```

As I currently see no performance difference between the last two and the last one once used index, I kept that version.

Tested on Pg11, Mac