### PR TITLE
Fix for RuntimeError on second local pipeline run on py3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.1 (2019-02-20)
+- Fix for Python 3.7 ("RuntimeError: context has already been set")
+
 ## 2.6.0 (2019-02-12)
 
 - Python 3.8 compatibility (explicitly set process spawning method to 'fork')
@@ -15,7 +18,7 @@
 
 ## 2.5.0 (2019-07-07)
 
-- Bug fix: make last modification timestamp of parallel file reading time zone aware (fixes `TypeError: can't compare offset-naive and offset-aware datetimes` error) 
+- Bug fix: make last modification timestamp of parallel file reading time zone aware (fixes `TypeError: can't compare offset-naive and offset-aware datetimes` error)
 
 
 ## 2.4.0 - 2.4.2 (2019-07-04)
@@ -61,7 +64,7 @@ ALTER TABLE data_integration_system_statistics ALTER timestamp TYPE timestamptz
 - Track and visualize also unfinished pipeline runs
 - Speed up computation of node durations and node cost
 - Improve error handling in launching of parallel tasks
-- Improve run times visualization (better axis labels, independent tooltips) 
+- Improve run times visualization (better axis labels, independent tooltips)
 - Smaller ui improvements
 
 
@@ -76,7 +79,7 @@ ALTER TABLE data_integration_system_statistics ALTER timestamp TYPE timestamptz
   how to not let passwords show up in the settings UI.
   ([gh #14](https://github.com/mara/data-integration/pull/14))
 
-**required changes** 
+**required changes**
 
 - Update `mara-app` to `>=2.0.0`
 
@@ -98,7 +101,7 @@ ALTER TABLE data_integration_system_statistics ALTER timestamp TYPE timestamptz
 **required changes**
 
 - When using `ParallelReadFile` with parameter `partition_target_table_by_day_id=True`, then make sure the target table is natively partitioned by adding `PARTITION BY LIST (day_id)`.
- 
+
 
 
 ## 1.3.0 (2018-07-17)

--- a/data_integration/execution.py
+++ b/data_integration/execution.py
@@ -36,10 +36,13 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
 
     # use forking for starting child processes to avoid cleanup functions and leakage and pickle problems
     # basically only py3.8 on mac uses spawn as default
+    #
     # Using fork on newer macs has it's own disadvantages: you need to set
     #   OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
     # env variable *before* starting python/flask otherwise you will get core dumps when any forked process calls
-    # into certain native code (e.g. requests)!
+    # into certain native code (e.g. requests)! Note that this is done automatically if you create your virtual env
+    # via the scripts from mara-app >= 2.1.1
+    #
     # You can only set this once, otherwise you get "RuntimeError: context has already been set"
     if multiprocessing.get_start_method(allow_none=True) != 'fork':
         multiprocessing.set_start_method('fork')

--- a/data_integration/execution.py
+++ b/data_integration/execution.py
@@ -33,9 +33,16 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
     Yields:
         Events emitted during pipeline execution
     """
-    
-    # use forking for starting child processes to avoid cleanup functions and leakage
-    multiprocessing.set_start_method('fork')
+
+    # use forking for starting child processes to avoid cleanup functions and leakage and pickle problems
+    # basically only py3.8 on mac uses spawn as default
+    # Using fork on newer macs has it's own disadvantages: you need to set
+    #   OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+    # env variable *before* starting python/flask otherwise you will get core dumps when any forked process calls
+    # into certain native code (e.g. requests)!
+    # You can only set this once, otherwise you get "RuntimeError: context has already been set"
+    if multiprocessing.get_start_method(allow_none=True) != 'fork':
+        multiprocessing.set_start_method('fork')
 
     # A queue for receiving events from forked sub processes
     event_queue = multiprocessing.Queue()


### PR DESCRIPTION
On my mac on py3.7 I get RuntimeError('context has already been set')
when multiprocessing.set_start_method('fork') is run during the the second
pipeline run (the first is fine).

```python
Debugging middleware caught exception in streamed response at a point where response headers were already sent.
Traceback (most recent call last):
  File ".venv/lib/python3.7/site-packages/werkzeug/wsgi.py", line 507, in __next__
    return self._next()
  File ".venv/lib/python3.7/site-packages/werkzeug/wrappers/base_response.py", line 45, in _iter_encoded
    for item in iterable:
  File "packages/data-integration/data_integration/ui/run_page.py", line 108, in process_events
    for event in execution.run_pipeline(pipeline, nodes, with_upstreams):
  File "packages/data-integration/data_integration/execution.py", line 45, in run_pipeline
    multiprocessing.set_start_method('fork')
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/context.py", line 242, in set_start_method
    raise RuntimeError('context has already been set')
```

The fix is to only set the start methog if this is not set to that value.