### PR TITLE
Fix inconsistent state after error

### DIFF
--- a/data_integration/commands/sql.py
+++ b/data_integration/commands/sql.py
@@ -114,6 +114,13 @@ class ExecuteSQL(_SQLCommand):
                                                  self.file_dependencies):
                 logger.log('no changes')
                 return True
+            else:
+                # delete any old hash to trigger a run in case the next run is switched back to the old hash
+                # This prevents inconsistent state in case you do a deplyoment with bad SQL which fails and
+                # then revert.
+                # The hash would still be correct for the old state but the results of this file would
+                # probably not be there (usually the first step is a DROP).
+                file_dependencies.delete(self.node_path(), dependency_type)
 
         if not super().run():
             return False
@@ -172,6 +179,12 @@ class Copy(_SQLCommand):
                                                  self.file_dependencies):
                 logger.log('no changes')
                 return True
+            else:
+                # delete any old hash to trigger a run in case the next run is switched back to the old hash
+                # which in most cases would result in an newly created empty table but no load
+                # (see also above in ExecuteSQL)
+                file_dependencies.delete(self.node_path(), dependency_type)
+
 
         if not super().run():
             return False


### PR DESCRIPTION
There are two places where we could end up with inconsistent state between what the DB has and what the incremental copy state/ the file dependency hashes know about:

* Incremental copy: If one would do a TRUNCATE/rebuild of the target table and the resulting full load would error, the next run would be an incremental one (as the old comparison value would still be there) despite the table not fully loaded
* file dependencies: if you do a deploy, which results in a rerun and this rerun fails + this deploy is then reverted, the old file dependencies would match and not trigger a rerun despite the DB not being in a fully functional state  

In both cases, we now simply delete the old state before the action (copy/execute) is attempted. This should trigger a full copy in the next run in case the copy is not successful/ a full run if the deploy is reverted.

Closes: #18