### PR TITLE
S3 file reader support

### DIFF
--- a/data_integration/commands/files.py
+++ b/data_integration/commands/files.py
@@ -119,6 +119,51 @@ class ReadFile(_ReadFile):
 
     def html_doc_items(self) -> [(str, str)]:
         return [('file name', _.i[self.file_name])] + super().html_doc_items()
+
+
+class ReadS3File(_ReadFile):
+    """Reads data from a S3 file"""
+
+    def __init__(self, s3_url: str, compression: Compression, target_table: str,
+                 mapper_script_file_name: str = None, make_unique: bool = False,
+                 db_alias: str = None, csv_format: bool = False, skip_header: bool = False,
+                 delimiter_char: str = None, quote_char: str = None,
+                 null_value_string: str = None, timezone: str = None,
+                 aws_access_key_id: str = None, aws_secret_access_key: str = None, aws_profile: str = None
+                 ) -> None:
+        super().__init__(compression=compression,
+                         target_table=target_table,
+                         mapper_script_file_name=mapper_script_file_name,
+                         make_unique=make_unique,
+                         db_alias=db_alias,
+                         csv_format=csv_format,
+                         skip_header=skip_header,
+                         delimiter_char=delimiter_char,
+                         quote_char=quote_char,
+                         null_value_string=null_value_string,
+                         timezone=timezone)
+        self.s3_url = s3_url
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.aws_profile = aws_profile
+
+    def read_file_command(self):
+        env_vars = ''
+        if self.aws_access_key_id:
+            env_vars = f'  AWS_ACCESS_KEY_ID={self.aws_access_key_id} AWS_SECRET_ACCESS_KEY={self.aws_secret_access_key}'
+        profile = ''
+        if self.aws_profile:
+            profile = f'--profile {self.aws_profile}'
+        return (f" {env_vars} aws {profile} s3 cp '{self.s3_url}' - \\\n"
+                + f'  | {uncompressor(self.compression)} - ')
+
+    def html_doc_items(self) -> [(str, str)]:
+        return [('AWS s3 url', _.i[self.s3_url]),
+                ('AWS credentials', _.i[self.aws_access_key_id]) if self.aws_access_key_id else '',
+                ('AWS profile', _.i[self.aws_profile]) if self.aws_profile else '',
+                ] + super().html_doc_items()
+
+
 class ReadSQLite(sql._SQLCommand):
     def __init__(self, sqlite_file_name: str, target_table: str,
                  sql_statement: str = None, sql_file_name: str = None, replace: {str: str} = None,

--- a/data_integration/commands/sql.py
+++ b/data_integration/commands/sql.py
@@ -8,6 +8,7 @@ from typing import Callable, Union
 
 import mara_db.dbs
 import mara_db.shell
+import mara_db.postgresql
 from mara_page import _, html
 from .. import config, shell, pipelines
 from ..incremental_processing import file_dependencies

--- a/data_integration/parallel_tasks/files.py
+++ b/data_integration/parallel_tasks/files.py
@@ -119,7 +119,7 @@ class _ParallelRead(pipelines.ParallelTask):
             if not isinstance(mara_db.dbs.db(self.db_alias), mara_db.dbs.PostgreSQLDB):
                 raise NotImplementedError(
                     f'Partitioning by day_id has only been implemented for postgresql so far, \n'
-                    f'not for {mara_db.postgresql.engine(self.db_alias).name}')
+                    f'not for {mara_db.dbs.db(self.db_alias).__class__.__name__}')
             files_per_day = {}
             for (file, date) in files:
                 if date in files_per_day:

--- a/data_integration/pipelines.py
+++ b/data_integration/pipelines.py
@@ -150,8 +150,8 @@ class ParallelTask(Node):
 
 class Pipeline(Node):
     nodes: {str: Node} = None
-    initial_node: Node = None
-    final_node: Node = None
+    initial_node: Task = None
+    final_node: Task = None
 
     def __init__(self, id: str,
                  description: str,
@@ -264,14 +264,14 @@ class Pipeline(Node):
         upstream.downstreams.discard(downstream)
         downstream.upstreams.discard(upstream)
 
-    def add_initial(self, node: Node) -> 'Pipeline':
+    def add_initial(self, node: Task) -> 'Pipeline':
         self.initial_node = node
         for downstream in self.nodes.values():
             if not downstream.upstreams and downstream != self.final_node:
                 self.add_dependency(node, downstream)
         self.add(node)
 
-    def add_final(self, node: Node) -> 'Pipeline':
+    def add_final(self, node: Task) -> 'Pipeline':
         self.final_node = node
         for upstream in self.nodes.values():
             if not upstream.downstreams and upstream != self.initial_node:


### PR DESCRIPTION
Refactors the file reader and adds s3 file reader as an alternative to local file reads.

New commands: 
* `data_integration.parallel_tasks.files.ParallelReadS3File`: reads in a whole bucket
* `data_integration.commands.files.ReadS3File`: reads a single file from S3

From initial testing, this is a lot slower than sync + reading from a local file system (both iterating over the bucket to get the file list and the individual reads...) but then syncing that bucket to a local filesystem is also taking time... From my perspective this is only worth it if you have to do a "sync to local" every time (which we have to do, not volumns in our ETL container :-(), so the second run is then saving time compared to doing a sync + incremental read via file system. That's at least the theory, up to now I only tested locally.

The single file read will also come in handy as a replacement of google sheet imports.

WIP...