### PR TITLE
Event logging in case of error

### DIFF
--- a/data_integration/events.py
+++ b/data_integration/events.py
@@ -16,31 +16,6 @@ class Event():
                            for field, value in self.__dict__.items()})
 
 
-class GenericExceptionEvent(Event):
-    def __init__(self, exception: BaseException, msg:str) -> None:
-        """
-        A generic Exception occurred during execution of the pipeline which could not be handled
-
-        Args:
-            exception: The BaseException
-            msg: an additional message
-        """
-        import traceback
-        super().__init__()
-        self.exception_type: str = str(type(exception).__name__)
-        self.exception_msg: str = str(exception)
-        self.exception_traceback: str = traceback.format_exc()
-        self.msg = msg
-        # make it easier in the web UI by precomputing it
-        if self.msg:
-            self._repr = f"{self.msg}: {self.exception_type}({self.exception_msg})"
-        else:
-            self._repr =  f"{self.exception_type}({self.exception_msg})"
-
-    def __repr__(self):
-        return self._repr
-
-
 class EventHandler(abc.ABC):
     @abc.abstractmethod
     def handle_event(self, event: Event):

--- a/data_integration/events.py
+++ b/data_integration/events.py
@@ -1,6 +1,7 @@
 import json
 import abc
 import datetime
+import sys
 
 
 class Event():
@@ -15,6 +16,31 @@ class Event():
                            for field, value in self.__dict__.items()})
 
 
+class GenericExceptionEvent(Event):
+    def __init__(self, exception: BaseException, msg:str) -> None:
+        """
+        A generic Exception occurred during execution of the pipeline which could not be handled
+
+        Args:
+            exception: The BaseException
+            msg: an additional message
+        """
+        import traceback
+        super().__init__()
+        self.exception_type: str = str(type(exception).__name__)
+        self.exception_msg: str = str(exception)
+        self.exception_traceback: str = traceback.format_exc()
+        self.msg = msg
+        # make it easier in the web UI by precomputing it
+        if self.msg:
+            self._repr = f"{self.msg}: {self.exception_type}({self.exception_msg})"
+        else:
+            self._repr =  f"{self.exception_type}({self.exception_msg})"
+
+    def __repr__(self):
+        return self._repr
+
+
 class EventHandler(abc.ABC):
     @abc.abstractmethod
     def handle_event(self, event: Event):
@@ -23,6 +49,14 @@ class EventHandler(abc.ABC):
 
 def notify_configured_event_handlers(event: Event):
     from . import config
-    all_handlers = config.event_handlers()
+    try:
+        all_handlers = config.event_handlers()
+    except BaseException as e:
+        print(f"Exception while getting configured event handlers: {repr(e)}", file=sys.stderr)
+        return
+
     for handler in all_handlers:
-        handler.handle_event(event)
+        try:
+            handler.handle_event(event)
+        except BaseException as e:
+            print(f"Handler {repr(handler)} could report about {repr(event)}: {repr(e)}", file=sys.stderr)

--- a/data_integration/logging/pipeline_events.py
+++ b/data_integration/logging/pipeline_events.py
@@ -21,10 +21,6 @@ class PipelineEvent(Event):
         super().__init__()
         self.node_path = node_path
 
-    def to_json(self):
-        return json.dumps({field: value.isoformat() if isinstance(value, datetime.datetime) else value
-                           for field, value in self.__dict__.items()})
-
 
 class RunStarted(PipelineEvent):
     def __init__(self, node_path: [str],
@@ -131,7 +127,7 @@ class Output(PipelineEvent):
         self.timestamp = datetime.datetime.now()
 
 
-def get_user_display_name(interactively_started:bool) -> t.Optional[str]:
+def get_user_display_name(interactively_started: bool) -> t.Optional[str]:
     """Gets the display name for the user which started a run
 
     Defaults to MARA_RUN_USER_DISPLAY_NAME and falls back to the current OS-level name

--- a/data_integration/notification/notifier.py
+++ b/data_integration/notification/notifier.py
@@ -9,7 +9,7 @@ class ChatNotifier(events.EventHandler, abc.ABC):
     def __init__(self):
         """ Abstract class for sending notifications to chat bots when pipeline errors occur"""
 
-        # keep a list of log messages and error log messsages for each node
+        # keep a list of log messages and error log messages for each node
         self.node_output: {tuple: {bool: [events.Event]}} = None
 
 
@@ -41,10 +41,14 @@ class ChatNotifier(events.EventHandler, abc.ABC):
         elif isinstance(event, pipeline_events.RunStarted):
             if event.interactively_started:
                 self.send_run_started_interactively_message(event)
+            # reset the saved outputs, just to be sure...
+            self.node_output = None
 
         elif isinstance(event, pipeline_events.RunFinished):
             if event.interactively_started:
                 self.send_run_finished_interactively_message(event)
+            # reset the saved outputs
+            self.node_output = None
 
     @abc.abstractmethod
     def send_run_started_interactively_message(self, event: pipeline_events.RunStarted):

--- a/data_integration/ui/cli.py
+++ b/data_integration/ui/cli.py
@@ -4,7 +4,7 @@ import sys
 
 import click
 
-from .. import config, pipelines, events
+from .. import config, pipelines
 
 
 def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
@@ -48,9 +48,6 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
             print(f'{theme[PATH_COLOR]}{" / ".join(event.node_path)}{":" if event.node_path else ""}{theme[RESET_ALL]} '
                   + theme[event.format] + (theme[ERROR_COLOR] if event.is_error else '')
                   + event.message + theme[RESET_ALL])
-        elif isinstance(event, events.GenericExceptionEvent):
-            print(theme[ERROR_COLOR] + repr(event) + theme[RESET_ALL])
-            print(theme[ERROR_COLOR] + event.exception_traceback + theme[RESET_ALL])
         elif isinstance(event, pipeline_events.RunFinished):
             if event.succeeded:
                 succeeded = True

--- a/data_integration/ui/cli.py
+++ b/data_integration/ui/cli.py
@@ -42,7 +42,7 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
 
     theme = plain if disable_colors else colorful
 
-    succeeded = True
+    succeeded = False
     for event in execution.run_pipeline(pipeline, nodes, with_upstreams, interactively_started=interactively_started):
         if isinstance(event, pipeline_events.Output):
             print(f'{theme[PATH_COLOR]}{" / ".join(event.node_path)}{":" if event.node_path else ""}{theme[RESET_ALL]} '
@@ -52,8 +52,8 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
             print(theme[ERROR_COLOR] + repr(event) + theme[RESET_ALL])
             print(theme[ERROR_COLOR] + event.exception_traceback + theme[RESET_ALL])
         elif isinstance(event, pipeline_events.RunFinished):
-            if not event.succeeded:
-                succeeded = False
+            if event.succeeded:
+                succeeded = True
 
     return succeeded
 

--- a/data_integration/ui/cli.py
+++ b/data_integration/ui/cli.py
@@ -4,7 +4,7 @@ import sys
 
 import click
 
-from .. import config, pipelines
+from .. import config, pipelines, events
 
 
 def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
@@ -48,6 +48,9 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
             print(f'{theme[PATH_COLOR]}{" / ".join(event.node_path)}{":" if event.node_path else ""}{theme[RESET_ALL]} '
                   + theme[event.format] + (theme[ERROR_COLOR] if event.is_error else '')
                   + event.message + theme[RESET_ALL])
+        elif isinstance(event, events.GenericExceptionEvent):
+            print(theme[ERROR_COLOR] + repr(event) + theme[RESET_ALL])
+            print(theme[ERROR_COLOR] + event.exception_traceback + theme[RESET_ALL])
         elif isinstance(event, pipeline_events.RunFinished):
             if not event.succeeded:
                 succeeded = False

--- a/data_integration/ui/static/run-page.js
+++ b/data_integration/ui/static/run-page.js
@@ -92,6 +92,15 @@ function processRunEvents(baseUrl, streamUrl, nodePath) {
         }
     }, false);
 
+        source.addEventListener('GenericExceptionEvent', function (e) {
+        var output = JSON.parse(e.data);
+        var msg = output._repr + '\n' + output.exception_traceback;
+        var message = formatNodeOutput(msg, 'italics', true);
+
+        mainOutputArea.append($('<div/>').append(message.clone()));
+        scrollContainersWithNewOutput.add('#main-output-area');
+    }, false);
+
     source.addEventListener('NodeStarted', function (e) {
         var event = JSON.parse(e.data);
         if (event.node_path.length == nodePath.length) {

--- a/data_integration/ui/static/run-page.js
+++ b/data_integration/ui/static/run-page.js
@@ -92,15 +92,6 @@ function processRunEvents(baseUrl, streamUrl, nodePath) {
         }
     }, false);
 
-        source.addEventListener('GenericExceptionEvent', function (e) {
-        var output = JSON.parse(e.data);
-        var msg = output._repr + '\n' + output.exception_traceback;
-        var message = formatNodeOutput(msg, 'italics', true);
-
-        mainOutputArea.append($('<div/>').append(message.clone()));
-        scrollContainersWithNewOutput.add('#main-output-area');
-    }, false);
-
     source.addEventListener('NodeStarted', function (e) {
         var event = JSON.parse(e.data);
         if (event.node_path.length == nodePath.length) {


### PR DESCRIPTION
Two problems in this PR: 
* No slack message when the mara DB is unreachable ("Notify when the runlogger.handle_event() throws an exception" // "Make event handling robust against exceptions during handling" and "Make the commandline only succeed if a RunFinished event arrived" make it more robust in general)
* Old error messages in slack when used in the browser and using multiple runs with errors without restarting flask ("Clean the message cache when a pipeline run starts and finishes")

The first showed up when the mara DB was shut down unexpectedly and we didn't get a slack notification (until our alerting based on last finish times kicked in). the second when you do SQL only fixes which need no restart...