### PR TITLE
Fix Problems when frontend and database are in a different timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## 2.8.1 (2020-04-27)
+
+- Fix Problems when frontend and database are in a different timezone (#34)
+
 ## 2.8.0 (2020-03-25)
 
 - Implement pipeline notifications via Microsoft Teams #28
 - Make it possible to disable output coloring in command line etl runs (#31)
-
 
 ## 2.7.0 (2020-03-05)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def get_long_description():
 
 setup(
     name='data-integration',
-    version='2.8.0',
+    version='2.8.1',
 
     description='Opinionated lightweight ETL pipeline framework',
 


### PR DESCRIPTION
The problem was that a) the frontend generated timestamps without timezones which postgresql then interpreted as the UTC but which were actually in the timezone which you ran the python code and b) the closing of open runs after an exception which kills the ETL runner itself (not individual tasks) after an error happened to insert a timestamp with timezone of the time on the postgresql server.

-> the error only happens when an exception happens which triggers this code path, e.g. because something shuts down the the runner (e.g. docker instance is shut down or ctrl+c on the command line).

Should fix https://github.com/mara/mara-example-project/issues/12
