### PR TITLE
Cleaner shutdown

### DIFF
--- a/data_integration/execution.py
+++ b/data_integration/execution.py
@@ -114,7 +114,7 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
             executor_pid = os.getpid()
 
             def ensure_task_processes_killed():
-                # as we fork, the TaskProcess also run this function -> ignore it there
+                # as we fork, the TaskProcess also runs this function -> ignore it there
                 if os.getpid() != executor_pid: return
                 try:
                     for tp in list(running_task_processes.values()):  # type: TaskProcess

--- a/data_integration/execution.py
+++ b/data_integration/execution.py
@@ -393,6 +393,8 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
                 pass
             return
         if not run_process.is_alive():
+            # If we are here it might be that the executor dies without sending the necessary run finished events
+            ensure_closed_run_on_abort()
             break
         time.sleep(0.001)
 

--- a/data_integration/execution.py
+++ b/data_integration/execution.py
@@ -374,7 +374,11 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
                 print(f"{repr(e)}", file=sys.stderr)
                 yield e
                 events.notify_configured_event_handlers(e)
-
+            # try to terminate the run_process which itself will also cleanup in an atexit handler
+            try:
+                run_process.terminate()
+            except:
+                pass
             return
         if not run_process.is_alive():
             break


### PR DESCRIPTION
This makes some attempts to clean up during shutdown.

* The main thing is the atexit function in the `run_pipeline` function which simply closes a run/node_run when shutting down.
* The atexit in `run()` will shutdown any still running processes.
* It also attempts to kill the run_process when the run_pipeline process is shut down via strg+c. This should trigger the atexit function in `run()` so at least the children are killed. This does not do any attempt to do the same for any other signal yet

Also included is a fix to actually check all ancestors of a task when checking if any of them is already failed -> the effect is that we do not schedule any tasks from an already queued sub pipelines (like a parallel task) in case the parent of that subpipeline is failed.

With this in place I could successfully add some signal handler (not included yet, needs some more testing) which kills the running processes and closes the runs.  It also handles strg+c in flask better, at least I didn't see leftover processes anymore.

partly covers: https://github.com/mara/data-integration/issues/40